### PR TITLE
Add and link MIT license in documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Irwin Beyond
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ Developed by **Irwin Beyond** as part of the <em>Framework Programming Workshop<
 
 ---
 
+## 📄 License
+
+This project is open-sourced under the [MIT License](LICENSE).
+
+---
+
 <p align="center">
     <sub>Built with ❤️ using Laravel & Tailwind CSS</sub>
 </p>


### PR DESCRIPTION
This pull request introduces licensing information to the project by adding an MIT License file and updating the `README.md` to reference it.

Licensing updates:

* Added a new `LICENSE` file containing the full text of the MIT License, specifying the terms under which the software can be used, modified, and distributed.
* Updated the `README.md` to include a section referencing the MIT License and linking to the new `LICENSE` file.